### PR TITLE
fix:use the singleUsePublicString if its empty on options

### DIFF
--- a/packages/lexi/src/lib/encrypt.ts
+++ b/packages/lexi/src/lib/encrypt.ts
@@ -75,13 +75,13 @@ export const encryptForMe = async (
 export const decryptJWEWithLexi = async (
   encryptionPackage: EncryptionPackage,
   signer: SignWallet,
-  options: LexiOptions,
+  publicString: string,
   encryptionKeyBox: EncryptionKeyBox
 ): Promise<Record<string, unknown>> => {
   const publicSigningString = encryptionPackage.signingString;
 
   const finalEncryptKeyBox =
-    publicSigningString === options.publicSigningString
+    publicSigningString === publicString
       ? encryptionKeyBox
       : new EncryptionKeyBox();
 

--- a/packages/lexi/src/service/lexi.ts
+++ b/packages/lexi/src/service/lexi.ts
@@ -36,7 +36,7 @@ export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
     return decryptJWEWithLexi(
       JSON.parse(cyphertext),
       this.wallet,
-      this.options,
+      this.options.publicSigningString || singleUsePublicString,
       this.encryptionKeyBox
     );
   }

--- a/packages/lexi/test/service/lexi.spec.ts
+++ b/packages/lexi/test/service/lexi.spec.ts
@@ -299,12 +299,11 @@ describe("LexiWallet", () => {
     const obj = { hello: "world" };
 
     // Two wallets using the same signer and did
-    const lexiWalletEncrypt = new LexiWallet(signer, me, {
-      publicSigningString: "signing-string-encrypt",
-    });
+    const lexiWalletEncrypt = new LexiWallet(signer, me, {});
     const lexiWalletDecrypt = new LexiWallet(signer, me, {
       publicSigningString: "singing-string-decrypt",
     });
+    const lexiWalletDecryptNoString = new LexiWallet(signer, me, {});
 
     // We encrypt using both wallet and try do decrypt both with the second one
     // We need to encrypt with the second so it cache the keys
@@ -312,8 +311,12 @@ describe("LexiWallet", () => {
     const encryptedSecond = await lexiWalletDecrypt.encryptForMe(obj);
     const decryptedFirst = await lexiWalletDecrypt.decrypt(encryptedFirst);
     const decryptedSecond = await lexiWalletDecrypt.decrypt(encryptedSecond);
+    const decryptedSecondNoString = await lexiWalletDecryptNoString.decrypt(
+      encryptedSecond
+    );
 
     expect(decryptedFirst).to.eql(obj);
     expect(decryptedSecond).to.eql(obj);
+    expect(decryptedSecondNoString).to.eql(obj);
   });
 });


### PR DESCRIPTION
If no signing string is defined on the options, pass the singleUsePublicString to decrypt. This will avoid asking to sign the message multiple times on the wallet.