### PR TITLE
CPASS-204: Cache all signed messages

### DIFF
--- a/packages/lexi/src/lib/encrypt.ts
+++ b/packages/lexi/src/lib/encrypt.ts
@@ -14,7 +14,7 @@ import {
 } from "./key";
 import type { SignWallet } from "./wallet";
 
-type EncryptionPackage = {
+export type EncryptionPackage = {
   signingString: string;
   schema: string;
   algorithm: string;

--- a/packages/lexi/src/service/lexi.ts
+++ b/packages/lexi/src/service/lexi.ts
@@ -1,10 +1,11 @@
+import EncryptionKeyBox from "src/lib/encryption_key_box";
 import type { LexiOptions } from "../lib/did";
 import {
   decryptJWEWithLexi,
   encryptForDid,
   encryptForMe,
+  EncryptionPackage,
 } from "../lib/encrypt";
-import EncryptionKeyBox from "../lib/encryption_key_box";
 import {
   generateX25519KeyPairFromSignature,
   singleUsePublicString,
@@ -15,29 +16,42 @@ export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
   private readonly wallet: SignWallet;
   private myDID: string;
   private readonly options: LexiOptions;
-  private readonly encryptionKeyBox: EncryptionKeyBox;
+  // a list of keyboxes indexed by the signingString
+  // this is necessary because each message can have a different string so it's cached to avoid multiple sign calls
+  private readonly encryptionKeyBoxes: Record<string, EncryptionKeyBox>;
 
   constructor(wallet: SignWallet, myDID: string, options: LexiOptions = {}) {
     this.wallet = wallet;
     this.myDID = myDID;
     this.options = options;
-    this.encryptionKeyBox = new EncryptionKeyBox();
+    this.encryptionKeyBoxes = {};
+  }
+
+  getEncryptionKeyBox(signingString?: string): EncryptionKeyBox {
+    const key =
+      signingString ||
+      this.options.publicSigningString ||
+      singleUsePublicString;
+    const value = this.encryptionKeyBoxes[key] || new EncryptionKeyBox();
+    this.encryptionKeyBoxes[key] = value;
+    return value;
   }
 
   async generateKeyForSigning() {
     await generateX25519KeyPairFromSignature(
       this.wallet,
       this.options.publicSigningString || singleUsePublicString,
-      this.encryptionKeyBox
+      this.getEncryptionKeyBox()
     );
   }
 
   decrypt(cyphertext: string): Promise<Record<string, unknown>> {
+    const parsedText = JSON.parse(cyphertext) as EncryptionPackage;
     return decryptJWEWithLexi(
-      JSON.parse(cyphertext),
+      parsedText,
       this.wallet,
       this.options.publicSigningString || singleUsePublicString,
-      this.encryptionKeyBox
+      this.getEncryptionKeyBox(parsedText.signingString)
     );
   }
 
@@ -53,7 +67,7 @@ export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
       this.myDID,
       this.wallet,
       this.options,
-      this.encryptionKeyBox
+      this.getEncryptionKeyBox()
     ).then(JSON.stringify);
   }
 

--- a/packages/lexi/test/service/lexi.spec.ts
+++ b/packages/lexi/test/service/lexi.spec.ts
@@ -319,4 +319,49 @@ describe("LexiWallet", () => {
     expect(decryptedSecond).to.eql(obj);
     expect(decryptedSecondNoString).to.eql(obj);
   });
+
+  it("should cache the signMessage result for publicSigningString in the instance", async () => {
+    const signKey = sign.keyPair();
+    const signer = new SignWalletWithKey(signKey);
+
+    // derive my did from this signing key
+    const me = "did:sol:" + encode(signKey.publicKey);
+
+    sinon.spy(signer, "signMessage");
+
+    // The data we want to encrypt
+    const obj = { hello: "world" };
+
+    const lexiWallet = new LexiWallet(signer, me, {});
+
+    const encryptedFirst = await lexiWallet.encryptForMe(obj);
+    const encryptedSecond = await lexiWallet.encryptForMe(obj);
+    await lexiWallet.decrypt(encryptedFirst);
+    await lexiWallet.decrypt(encryptedSecond);
+
+    expect(signer.signMessage.calledOnce).to.be.true;
+  });
+
+  it("should cache the signMessage result for publicSigningString in the cypher text", async () => {
+    const signKey = sign.keyPair();
+    const signer = new SignWalletWithKey(signKey);
+
+    // derive my did from this signing key
+    const me = "did:sol:" + encode(signKey.publicKey);
+
+    sinon.spy(signer, "signMessage");
+
+    // The data we want to encrypt
+    const obj = { hello: "world" };
+
+    const lexiWalletEncrypt = new LexiWallet(signer, me, {});
+    const lexiWallet = new LexiWallet(signer, me, {});
+
+    const encryptedFirst = await lexiWalletEncrypt.encryptForMe(obj);
+    const encryptedSecond = await lexiWalletEncrypt.encryptForMe(obj);
+    await lexiWallet.decrypt(encryptedFirst);
+    await lexiWallet.decrypt(encryptedSecond);
+
+    expect(signer.signMessage.callCount).to.eq(2);
+  });
 });


### PR DESCRIPTION
Once a message is signed using the `publicSigninString` of the `LexiWallet` instance, the result is cached so the signature is not requested again if necessary. This won't happen if the signed message is for another string. 

This PR will cache all the results so the `signMessage` method won't be called if the message was previously signed.