### PR TITLE
CPASS-204: Generate new signingString to each wallet

### DIFF
--- a/packages/lexi/src/index.ts
+++ b/packages/lexi/src/index.ts
@@ -2,4 +2,4 @@ export { LexiWallet } from "./service/lexi";
 export { SignWallet } from "./lib/wallet";
 export { Resolver, LexiOptions } from "./lib/did";
 export { DIDDocument } from "did-resolver";
-export { singleUsePublicString } from "./lib/key";
+export { generateRandomString } from "./lib/key";

--- a/packages/lexi/src/lib/key.ts
+++ b/packages/lexi/src/lib/key.ts
@@ -10,9 +10,8 @@ const PUBLIC_STRING_LENGTH = 32;
 export const newNonce = () => randomBytes(secretbox.nonceLength);
 
 // Generate a string that will seed the "lexi magic". This is assumed to be public knowledge.
-export const singleUsePublicString = base64.encode(
-  randomBytes(PUBLIC_STRING_LENGTH)
-);
+export const generateRandomString = () =>
+  base64.encode(randomBytes(PUBLIC_STRING_LENGTH));
 
 const SHA256D = async (input: Uint8Array): Promise<Uint8Array> => {
   const first = crypto.createHash("sha256");

--- a/packages/lexi/test/service/lexi.spec.ts
+++ b/packages/lexi/test/service/lexi.spec.ts
@@ -364,4 +364,22 @@ describe("LexiWallet", () => {
 
     expect(signer.signMessage.callCount).to.eq(2);
   });
+
+  it("should generate different signing string for different lexi wallets", async () => {
+    const signKey = sign.keyPair();
+    const signer = new SignWalletWithKey(signKey);
+
+    // derive my did from this signing key
+    const me = "did:sol:" + encode(signKey.publicKey);
+
+    // The data we want to encrypt
+    const obj = { hello: "world" };
+
+    const wallet1 = new LexiWallet(signer, me, {});
+    const wallet2 = new LexiWallet(signer, me, {});
+
+    expect(wallet1["singleUsePublicString"]).to.not.eq(
+      wallet2["singleUsePublicString"]
+    );
+  });
 });


### PR DESCRIPTION
The publicSigningString is a global variable generated when key.ts is loaded. This means all wallets generated in the same session will use the same string. This PR fixes this issue and makes the string bound to the LexiWallet, ensuring each wallet has its unique string.