### PR TITLE
Add caching inside lexi for signing 

### DIFF
--- a/packages/lexi/src/lib/wallet.ts
+++ b/packages/lexi/src/lib/wallet.ts
@@ -16,3 +16,22 @@ interface EncryptionWallet {
 export interface PersonalEncryptionWallet extends EncryptionWallet {
   encryptForMe(plaintext: Uint8Array): Promise<EncryptionPackage>;
 }
+
+// A wallet that caches signd messages to avoid multiple calls to the wallet
+export class CachedSignWallet implements SignWallet {
+  private readonly wallet: SignWallet;
+  private readonly cache: Record<string, Uint8Array>;
+
+  constructor(wallet: SignWallet) {
+    this.wallet = wallet;
+    this.cache = {};
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    const key = message.toString();
+    if (!this.cache[key]) {
+      this.cache[key] = await this.wallet.signMessage(message);
+    }
+    return this.cache[key] as Uint8Array;
+  }
+}

--- a/packages/lexi/src/lib/wallet.ts
+++ b/packages/lexi/src/lib/wallet.ts
@@ -17,7 +17,7 @@ export interface PersonalEncryptionWallet extends EncryptionWallet {
   encryptForMe(plaintext: Uint8Array): Promise<EncryptionPackage>;
 }
 
-// A wallet that caches signd messages to avoid multiple calls to the wallet
+// A wallet that caches signed messages to avoid multiple calls to the wallet
 export class CachedSignWallet implements SignWallet {
   private readonly wallet: SignWallet;
   private readonly cache: Record<string, Uint8Array>;

--- a/packages/lexi/src/lib/wallet.ts
+++ b/packages/lexi/src/lib/wallet.ts
@@ -1,5 +1,5 @@
 import type { EncryptionPackage } from "./encrypt";
-import type {JWE} from "did-jwt";
+import type { JWE } from "did-jwt";
 
 export interface SignWallet {
   signMessage(message: Uint8Array): Promise<Uint8Array>;
@@ -20,7 +20,7 @@ export interface PersonalEncryptionWallet extends EncryptionWallet {
 // A wallet that caches signed messages to avoid multiple calls to the wallet
 export class CachedSignWallet implements SignWallet {
   private readonly wallet: SignWallet;
-  private readonly cache: Record<string, Uint8Array>;
+  private readonly cache: Record<string, Promise<Uint8Array>>;
 
   constructor(wallet: SignWallet) {
     this.wallet = wallet;
@@ -30,8 +30,8 @@ export class CachedSignWallet implements SignWallet {
   async signMessage(message: Uint8Array): Promise<Uint8Array> {
     const key = message.toString();
     if (!this.cache[key]) {
-      this.cache[key] = await this.wallet.signMessage(message);
+      this.cache[key] = this.wallet.signMessage(message);
     }
-    return this.cache[key] as Uint8Array;
+    return (await this.cache[key]) as Uint8Array;
   }
 }

--- a/packages/lexi/src/service/lexi.ts
+++ b/packages/lexi/src/service/lexi.ts
@@ -10,7 +10,7 @@ import {
   generateRandomString,
   generateX25519KeyPairFromSignature,
 } from "../lib/key";
-import type { PersonalEncryptionWallet, SignWallet } from "../lib/wallet";
+import {CachedSignWallet, type PersonalEncryptionWallet, type SignWallet} from "../lib/wallet";
 import type {JWE} from "did-jwt";
 
 export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
@@ -23,7 +23,7 @@ export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
   private readonly encryptionKeyBoxes: Record<string, EncryptionKeyBox>;
 
   constructor(wallet: SignWallet, myDID: string, options: LexiOptions = {}) {
-    this.wallet = wallet;
+    this.wallet = new CachedSignWallet(wallet);
     this.myDID = myDID;
     this.options = options;
     this.singleUsePublicString =
@@ -39,7 +39,7 @@ export class LexiWallet implements PersonalEncryptionWallet, SignWallet {
   }
 
   async generateKeyForSigning() {
-    await generateX25519KeyPairFromSignature(
+    return generateX25519KeyPairFromSignature(
       this.wallet,
       this.singleUsePublicString,
       this.getEncryptionKeyBox()

--- a/packages/lexi/test/service/lexi.spec.ts
+++ b/packages/lexi/test/service/lexi.spec.ts
@@ -191,6 +191,26 @@ describe("LexiWallet", () => {
     expect(bytesToObj(decrypted)).to.eql(obj);
   });
 
+  it("We create a LexiWallet and call the encrypt method twice - should only sign once", async () => {
+    const signKey = sign.keyPair();
+    const signer = new SignWalletWithKey(signKey);
+
+    // derive my did from this signing key
+    const me = "did:sol:" + encode(signKey.publicKey);
+
+    // The data we want to encrypt
+    const obj = { hello: "world" };
+
+    sinon.spy(signer, "signMessage");
+
+    // encrypt and decrypt using lexi-aware wallet
+    const lexiWallet = new LexiWallet(signer, me, {});
+    await lexiWallet.encryptForMe(objToBytes(obj));
+    await lexiWallet.encryptForMe(objToBytes(obj));
+
+    expect((signer.signMessage as SinonSpy).calledOnce).to.be.true;
+  });
+
   it("We create a LexiWallet without any options", async () => {
     // restore sandbox so we can reset the stub
     sandbox.restore();

--- a/packages/lexi/test/service/lexi.spec.ts
+++ b/packages/lexi/test/service/lexi.spec.ts
@@ -9,8 +9,8 @@ import type { DIDResolutionResult } from "did-resolver";
 import * as sinon from "sinon";
 import chaiAsPromised from "chai-as-promised";
 import "mocha";
-import {SinonSpy} from "sinon";
-import {bytesToObj, objToBytes} from "../../src";
+import { SinonSpy } from "sinon";
+import { bytesToObj, objToBytes } from "../../src";
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
@@ -34,9 +34,10 @@ describe("LexiWallet", () => {
               {
                 id: "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa#default",
                 type: "Ed25519VerificationKey2018",
-                controller: "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
-                publicKeyBase58: "6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa"
-              }
+                controller:
+                  "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
+                publicKeyBase58: "6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
+              },
             ],
             authentication: [],
             assertionMethod: [],
@@ -46,12 +47,15 @@ describe("LexiWallet", () => {
             ],
             capabilityDelegation: [],
             service: [],
-            publicKey: [{
-              id: "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa#default",
-              type: "Ed25519VerificationKey2018",
-              controller: "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
-              publicKeyBase58: "6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa"
-            }],
+            publicKey: [
+              {
+                id: "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa#default",
+                type: "Ed25519VerificationKey2018",
+                controller:
+                  "did:sol:6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
+                publicKeyBase58: "6n853y6agbzauRS9BhkovVF2EuGux4C7iq7RFdZPhYPa",
+              },
+            ],
           },
           content: null,
           contentType: null,
@@ -186,7 +190,9 @@ describe("LexiWallet", () => {
     const encryptedWithWallet = await lexiWallet.encryptForMe(objToBytes(obj));
     const decrypted = await lexiWallet.decrypt(encryptedWithWallet);
 
-    await expect(lexiWallet.encrypt(objToBytes(obj), me)).to.be.rejectedWith(/Could not find X25519 key/);
+    await expect(lexiWallet.encrypt(objToBytes(obj), me)).to.be.rejectedWith(
+      /Could not find X25519 key/
+    );
 
     expect(bytesToObj(decrypted)).to.eql(obj);
   });
@@ -316,7 +322,9 @@ describe("LexiWallet", () => {
 
     // encrypt and decrypt using lexi-aware wallet
     const lexiWallet = new LexiWallet(signer, me);
-    return expect(lexiWallet.encryptForMe(objToBytes(obj))).to.eventually.be.rejectedWith(
+    return expect(
+      lexiWallet.encryptForMe(objToBytes(obj))
+    ).to.eventually.be.rejectedWith(
       `resolver_error: Could not resolve did:sol:${encode(
         signKey.publicKey
       )}: undefined, undefined`
@@ -342,8 +350,12 @@ describe("LexiWallet", () => {
 
     // We encrypt using both wallet and try to decrypt both with the second one
     // We need to encrypt with the second so it cache the keys
-    const encryptedFirst = await lexiWalletEncrypt.encryptForMe(objToBytes(obj));
-    const encryptedSecond = await lexiWalletDecrypt.encryptForMe(objToBytes(obj));
+    const encryptedFirst = await lexiWalletEncrypt.encryptForMe(
+      objToBytes(obj)
+    );
+    const encryptedSecond = await lexiWalletDecrypt.encryptForMe(
+      objToBytes(obj)
+    );
     const decryptedFirst = await lexiWalletDecrypt.decrypt(encryptedFirst);
     const decryptedSecond = await lexiWalletDecrypt.decrypt(encryptedSecond);
     const decryptedSecondNoString = await lexiWalletDecryptNoString.decrypt(
@@ -369,10 +381,11 @@ describe("LexiWallet", () => {
 
     const lexiWallet = new LexiWallet(signer, me, {});
 
-    const encryptedFirst = await lexiWallet.encryptForMe(objToBytes(obj));
-    const encryptedSecond = await lexiWallet.encryptForMe(objToBytes(obj));
-    await lexiWallet.decrypt(encryptedFirst);
-    await lexiWallet.decrypt(encryptedSecond);
+    const encrypted = await Promise.all([
+      lexiWallet.encryptForMe(objToBytes(obj)),
+      lexiWallet.encryptForMe(objToBytes(obj)),
+    ]);
+    await Promise.all(encrypted.map((e) => lexiWallet.decrypt(e)));
 
     expect((signer.signMessage as SinonSpy).calledOnce).to.be.true;
   });
@@ -392,8 +405,12 @@ describe("LexiWallet", () => {
     const lexiWalletEncrypt = new LexiWallet(signer, me, {});
     const lexiWallet = new LexiWallet(signer, me, {});
 
-    const encryptedFirst = await lexiWalletEncrypt.encryptForMe(objToBytes(obj));
-    const encryptedSecond = await lexiWalletEncrypt.encryptForMe(objToBytes(obj));
+    const encryptedFirst = await lexiWalletEncrypt.encryptForMe(
+      objToBytes(obj)
+    );
+    const encryptedSecond = await lexiWalletEncrypt.encryptForMe(
+      objToBytes(obj)
+    );
     await lexiWallet.decrypt(encryptedFirst);
     await lexiWallet.decrypt(encryptedSecond);
 


### PR DESCRIPTION
Update to handle multiple simultaneous requests so we only ask for a single sign message for multiple encryption requests from the same instance